### PR TITLE
Make `Elements` return a `Sequence` to allow lazy parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `Innmind\Html\Element\*` classes now implement `Innmind\Xml\Element\Custom`
 - `Innmind\Html\Node\Document` no longer implement any interface
 - `Innmind\Html\Reader\Reader` now return an `Innmind\Immutable\Attempt`
+- `Innmind\Html\Visitor\Elements` now return a `Innmind\Immutable\Sequence`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ use Innmind\Html\Visitor\Elements;
 $h1s = Elements::of('h1')($html);
 ```
 
-Here `$h1s` is a set of `Element` which are all `h1` elements.
+Here `$h1s` is a sequence of `Element` which are all `h1` elements.
 
 Here's the full list of visitors you have access to:
 

--- a/tests/Visitor/ElementsTest.php
+++ b/tests/Visitor/ElementsTest.php
@@ -12,7 +12,7 @@ use Innmind\Xml\{
     Element\Name,
 };
 use Innmind\Filesystem\File\Content;
-use Innmind\Immutable\Set;
+use Innmind\Immutable\Sequence;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class ElementsTest extends TestCase
@@ -35,7 +35,7 @@ class ElementsTest extends TestCase
 
         $h1s = Elements::of('h1')($node);
 
-        $this->assertInstanceOf(Set::class, $h1s);
+        $this->assertInstanceOf(Sequence::class, $h1s);
         $this->assertCount(26, $h1s);
     }
 
@@ -43,7 +43,7 @@ class ElementsTest extends TestCase
     {
         $elements = Elements::of('foo')(Element::of(Name::of('whatever')));
 
-        $this->assertInstanceOf(Set::class, $elements);
+        $this->assertInstanceOf(Sequence::class, $elements);
         $this->assertCount(0, $elements);
     }
 }


### PR DESCRIPTION
Fix #1 